### PR TITLE
Use a `Map` to store the observers

### DIFF
--- a/src/forking-store.js
+++ b/src/forking-store.js
@@ -14,7 +14,7 @@ export default class ForkingStore {
   graph = graph();
   fetcher = null;
   updater = null;
-  observers = {};
+  observers = new Map();
 
   constructor() {
     this.fetcher = new Fetcher(this.graph);
@@ -261,18 +261,18 @@ export default class ForkingStore {
    */
   registerObserver(observer, key) {
     key = key || observer;
-    this.observers[key] = observer;
+    this.observers.set(key, observer);
   }
 
   deregisterObserver(key) {
-    delete this.observers[key];
+    this.observers.delete(key);
   }
 
   /**
    * Removes all the registered observers. This can be used before destroying the form to prevent the observer callback looping.
    */
   clearObservers() {
-    this.observers = {};
+    this.observers.clear();
   }
 }
 
@@ -308,9 +308,9 @@ function statementInGraph(quad, graph) {
 }
 
 function informObservers(payload, forkingStore) {
-  for (const observerKey in forkingStore.observers) {
+  for (const [observerKey, observer] of forkingStore.observers.entries()) {
     try {
-      forkingStore.observers[observerKey](payload);
+      observer(payload);
     } catch (e) {
       console.error(
         `Something went wrong during the callback of observer ${observerKey}`,

--- a/tests/forking-store-test.js
+++ b/tests/forking-store-test.js
@@ -50,8 +50,8 @@ describe("ForkingStore", () => {
       const observerA = mock.fn();
       const observerB = mock.fn();
 
-      store.registerObserver(observerA, "observer-a");
-      store.registerObserver(observerB, "observer-b");
+      store.registerObserver(observerA);
+      store.registerObserver(observerB);
       assert.equal(observerA.mock.callCount(), 0);
       assert.equal(observerB.mock.callCount(), 0);
 


### PR DESCRIPTION
The object implementation causes functions to be `toString`ed since objects only support string keys. This had the side-effect that functions with the same string representation would override each other in the observer object. 

I don't think it's a bugfix since chances of this happening in regular code seems small? I'm guessing most observers functions would have a unique string representation.

While writing tests for #21 I noticed that the second mock observer was overwriting the first one. This PR [fixes it.](https://github.com/redpencilio/forking-store/pull/22/files#diff-c33c731c743a98232d437a18a298bceea4842a18a3ecac3caa48110be0721b0bR53-R54)

Builds on #21 so that needs to be merged first.