### PR TITLE
Fix a potential infinite loop in the observer system

### DIFF
--- a/src/forking-store.js
+++ b/src/forking-store.js
@@ -308,7 +308,7 @@ function statementInGraph(quad, graph) {
 }
 
 function informObservers(payload, forkingStore) {
-  for (const [observerKey, observer] of forkingStore.observers.entries()) {
+  for (const [observerKey, observer] of [...forkingStore.observers.entries()]) {
     try {
       observer(payload);
     } catch (e) {


### PR DESCRIPTION
In #22 we accidentaly introduced a regression that could trigger infinite loops.

If observers register new (or the same) observer, the iterator in the informObservers util would also call that iterator which results in an infinite loop. Instead we convert the iterator into an array so new observers don't affect the current callbacks.