### PR TITLE
Batch observer calls

### DIFF
--- a/tests/forking-store-test.js
+++ b/tests/forking-store-test.js
@@ -45,6 +45,34 @@ describe("ForkingStore", () => {
       );
     });
 
+    test("store.addAll passes an object to the observer with the added triples under the `inserts` key", () => {
+      const store = new ForkingStore();
+      const observer = mock.fn();
+
+      store.registerObserver(observer);
+      assert.equal(observer.mock.callCount(), 0);
+
+      const inserts = [randomQuad(), randomQuad()];
+      store.addAll(inserts);
+
+      const call = observer.mock.calls.at(0);
+      assert.deepEqual(call.arguments.at(0), { inserts });
+    });
+
+    test("`store.removeStatements` passes an object to the observer with the added triples under the `deletes` key", () => {
+      const store = new ForkingStore();
+      const observer = mock.fn();
+
+      store.registerObserver(observer);
+      assert.equal(observer.mock.callCount(), 0);
+
+      const deletes = [randomQuad(), randomQuad()];
+      store.removeStatements(deletes);
+
+      const call = observer.mock.calls.at(0);
+      assert.deepEqual(call.arguments.at(0), { deletes });
+    });
+
     test("`clearObservers` removes all registered observers", () => {
       const store = new ForkingStore();
       const observerA = mock.fn();

--- a/tests/forking-store-test.js
+++ b/tests/forking-store-test.js
@@ -4,10 +4,11 @@ import test, { describe, mock } from "node:test";
 import { namedNode, quad } from "rdflib";
 
 import ForkingStore from "../src/forking-store.js";
+import { waitForIdleStore } from "./helpers/wait-for-idle-store.js";
 
 describe("ForkingStore", () => {
   describe("observers", () => {
-    test("observers can be used to receive store updates", () => {
+    test("observers can be used to receive store updates", async () => {
       const store = new ForkingStore();
       const observer = mock.fn();
 
@@ -15,10 +16,12 @@ describe("ForkingStore", () => {
       assert.equal(observer.mock.callCount(), 0);
 
       store.addAll([randomQuad()]);
+      await waitForIdleStore(store);
       assert.equal(observer.mock.callCount(), 1);
 
       store.deregisterObserver("unique-key");
       store.addAll([randomQuad()]);
+      await waitForIdleStore(store);
       assert.equal(
         observer.mock.callCount(),
         1,
@@ -26,7 +29,7 @@ describe("ForkingStore", () => {
       );
     });
 
-    test("the key argument on the `registerObserver` method is optional", () => {
+    test("the key argument on the `registerObserver` method is optional", async () => {
       const store = new ForkingStore();
       const observer = mock.fn();
 
@@ -34,10 +37,12 @@ describe("ForkingStore", () => {
       assert.equal(observer.mock.callCount(), 0);
 
       store.addAll([randomQuad()]);
+      await waitForIdleStore(store);
       assert.equal(observer.mock.callCount(), 1);
 
       store.deregisterObserver(observer);
       store.addAll([randomQuad()]);
+      await waitForIdleStore(store);
       assert.equal(
         observer.mock.callCount(),
         1,
@@ -45,7 +50,7 @@ describe("ForkingStore", () => {
       );
     });
 
-    test("store.addAll passes an object to the observer with the added triples under the `inserts` key", () => {
+    test("store.addAll passes an object to the observer with the added triples under the `inserts` key", async () => {
       const store = new ForkingStore();
       const observer = mock.fn();
 
@@ -54,12 +59,13 @@ describe("ForkingStore", () => {
 
       const inserts = [randomQuad(), randomQuad()];
       store.addAll(inserts);
+      await waitForIdleStore(store);
 
       const call = observer.mock.calls.at(0);
-      assert.deepEqual(call.arguments.at(0), { inserts });
+      assert.deepEqual(call.arguments.at(0), { inserts, deletes: [] });
     });
 
-    test("`store.removeStatements` passes an object to the observer with the added triples under the `deletes` key", () => {
+    test("`store.removeStatements` passes an object to the observer with the added triples under the `deletes` key", async () => {
       const store = new ForkingStore();
       const observer = mock.fn();
 
@@ -68,12 +74,42 @@ describe("ForkingStore", () => {
 
       const deletes = [randomQuad(), randomQuad()];
       store.removeStatements(deletes);
+      await waitForIdleStore(store);
 
       const call = observer.mock.calls.at(0);
-      assert.deepEqual(call.arguments.at(0), { deletes });
+      assert.deepEqual(call.arguments.at(0), { inserts: [], deletes });
     });
 
-    test("`clearObservers` removes all registered observers", () => {
+    test("multiple `addAll` and `removeStatements` calls will only trigger a single observer call", async () => {
+      const store = new ForkingStore();
+      const observer = mock.fn();
+
+      store.registerObserver(observer);
+      assert.equal(observer.mock.callCount(), 0);
+
+      let deletes = [randomQuad(), randomQuad()];
+      store.removeStatements(deletes);
+
+      let inserts = [randomQuad(), randomQuad()];
+      store.addAll(inserts);
+
+      await waitForIdleStore(store);
+
+      assert.equal(observer.mock.callCount(), 1);
+
+      let call = observer.mock.calls.at(0);
+      assert.deepEqual(call.arguments.at(0), { inserts, deletes });
+
+      inserts = [randomQuad(), randomQuad()];
+      store.addAll(inserts);
+      await waitForIdleStore(store);
+      assert.equal(observer.mock.callCount(), 2);
+
+      call = observer.mock.calls.at(1);
+      assert.deepEqual(call.arguments.at(0), { inserts, deletes: [] });
+    });
+
+    test("`clearObservers` removes all registered observers", async () => {
       const store = new ForkingStore();
       const observerA = mock.fn();
       const observerB = mock.fn();
@@ -84,11 +120,13 @@ describe("ForkingStore", () => {
       assert.equal(observerB.mock.callCount(), 0);
 
       store.addAll([randomQuad()]);
+      await waitForIdleStore(store);
       assert.equal(observerA.mock.callCount(), 1);
       assert.equal(observerB.mock.callCount(), 1);
 
       store.clearObservers();
       store.addAll([randomQuad()]);
+      await waitForIdleStore(store);
       assert.equal(observerA.mock.callCount(), 1);
       assert.equal(observerB.mock.callCount(), 1);
     });

--- a/tests/helpers/wait-for-idle-store.js
+++ b/tests/helpers/wait-for-idle-store.js
@@ -1,0 +1,26 @@
+/**
+ * Test helper that can be used to wait until the forking store is an "idle" state
+ * @param {*} forkingStore The forking store instance
+ * @param {number} maxWaitTime The maximum amount of time that should be waited. If the store isn't idle by that time an error will be thrown.
+ *
+ * @returns Promise<void> Returns a promise that resolves when the forking store is idle and rejects when the wait time is passed without it becoming idle.
+ */
+export function waitForIdleStore(forkingStore, maxWaitTime = 100) {
+  return new Promise((resolve, reject) => {
+    const startTime = new Date();
+    const id = setInterval(() => {
+      if (forkingStore._isIdle) {
+        clearInterval(id);
+        resolve();
+      } else {
+        const currentTime = new Date();
+        if (currentTime - startTime > maxWaitTime) {
+          clearInterval(id);
+          reject(
+            `The forking store didn't return to an idle state within the expected time of ${maxWaitTime}ms`,
+          );
+        }
+      }
+    }, 1);
+  });
+}


### PR DESCRIPTION
Some semantic forms can trigger a lot of synchronous data changes and as a consequence a lot of observer callbacks. By batching these data changes together we can reduce the amount of callbacks which potentially improves performance in case the handlers do heavy work.

It also makes it possible to analyse the data and remove redundant changes so the observers are only triggered if there are actual changes (in the current batch).

Part of DL-5317