### PR TITLE
Fix `addAll` and `removeStatements` data insertion timings

### DIFF
--- a/tests/forking-store-test.js
+++ b/tests/forking-store-test.js
@@ -7,6 +7,35 @@ import ForkingStore from "../src/forking-store.js";
 import { waitForIdleStore } from "./helpers/wait-for-idle-store.js";
 
 describe("ForkingStore", () => {
+  describe("addAll", () => {
+    test("addAll inserts statements in the store", async () => {
+      const store = new ForkingStore();
+
+      const testQuad = randomQuad();
+      let matches = store.match(
+        testQuad.subject,
+        testQuad.predicate,
+        testQuad.object,
+        testQuad.graph,
+      );
+
+      assert.equal(
+        matches.length,
+        0,
+        "The data hasn't been inserted in the store yet",
+      );
+
+      store.addAll([testQuad]);
+      matches = store.match(
+        testQuad.subject,
+        testQuad.predicate,
+        testQuad.object,
+        testQuad.graph,
+      );
+      assert.equal(matches.length, 1, "The data was inserted in the store");
+    });
+  });
+
   describe("observers", () => {
     test("observers can be used to receive store updates", async () => {
       const store = new ForkingStore();


### PR DESCRIPTION
I accidentally introduced a regression in #25.

Delaying the actual data insertion and removal in/from the store was an accidental breaking change. Consumers expect that the store is updated synchronously after using one of these methods.

We now immediately update the store again, while still delaying the observer callback to reduce the amount of calls.